### PR TITLE
Customizable ghostscript path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ See the following basic usage example.
 This will take in three input PDFs, stitch them together, and save out
 the result to `destinationDocument.pdf`. The documents will be stitched
 together in the order they are added.
+
+### Where Ghostscript is in an unusual location
+
+A path to a Ghostscript executable can be passed into the `PdfStitcher` constructor:
+
+```php
+new PdfStitcher('a/path/to/a/gs/executable')
+```

--- a/src/PdfStitcher.php
+++ b/src/PdfStitcher.php
@@ -108,7 +108,7 @@ class PdfStitcher
             $command = $this->overriddenGhostscriptExecutablePath;
         }
 
-        $command = ' -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile='.Utils::quote($filePath).' ';
+        $command .= ' -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile='.Utils::quote($filePath).' ';
         $command .= implode(' ', array_map([Utils::class, 'quote'], $this->inputFiles));
 
         return $command;

--- a/src/PdfStitcher.php
+++ b/src/PdfStitcher.php
@@ -19,6 +19,23 @@ class PdfStitcher
     private $inputFiles = [];
 
     /**
+     * A path to a Ghostscript executable to use instead of the default "gs".
+     * 
+     * @var ?string
+     */
+    private $overriddenGhostscriptExecutablePath = null;
+
+    /**
+     * Creates a new instance of the PDF stitcher.
+     * 
+     * @param ?string $overriddenGhostscriptExecutablePath A path to a Ghostscript executable to use instead of the default "gs".
+     */
+    public function __construct($overriddenGhostscriptExecutablePath)
+    {
+        $this->overriddenGhostscriptExecutablePath = $overriddenGhostscriptExecutablePath;
+    }
+
+    /**
      * Add a PDF to the list of files to be stitched together.
      *
      * @param string $filePath
@@ -81,11 +98,17 @@ class PdfStitcher
      */
     private function getShellCommand($filePath): string
     {
-        if (!$this->ghostscriptInstalled()) {
-            throw new RuntimeException('Ghostscript (`gs`) is not installed. Please install it.');
+        if ($this->overriddenGhostscriptExecutablePath === null) {
+            if (!$this->ghostscriptInstalled()) {
+                throw new RuntimeException('Ghostscript (`gs`) is not installed. Please install it.');
+            }
+
+            $command = 'gs';
+        } else {
+            $command = $this->overriddenGhostscriptExecutablePath;
         }
 
-        $command = 'gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile='.Utils::quote($filePath).' ';
+        $command = ' -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile='.Utils::quote($filePath).' ';
         $command .= implode(' ', array_map([Utils::class, 'quote'], $this->inputFiles));
 
         return $command;

--- a/src/PdfStitcher.php
+++ b/src/PdfStitcher.php
@@ -30,7 +30,7 @@ class PdfStitcher
      * 
      * @param ?string $overriddenGhostscriptExecutablePath A path to a Ghostscript executable to use instead of the default "gs".
      */
-    public function __construct($overriddenGhostscriptExecutablePath)
+    public function __construct($overriddenGhostscriptExecutablePath = null)
     {
         $this->overriddenGhostscriptExecutablePath = $overriddenGhostscriptExecutablePath;
     }


### PR DESCRIPTION
This allows the Ghostscript path to be overridden if it is not globally available on the PATH, e.g. when running under Valet.